### PR TITLE
Update auth.go

### DIFF
--- a/authenticator/auth.go
+++ b/authenticator/auth.go
@@ -76,7 +76,7 @@ func main() {
 		panic(err)
 	}
 
-	err = os.Mkdir(outputPath, 0666)
+	err = os.Mkdir(outputPath, 0777)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
data directory perms should be 0777 instead of 0666 or else the folder can't be written to later. I believe this wasn't caught because original development was on Windows and Windows doesn't care about folder execution perms.